### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,6 @@
 name: CI
+permissions:
+    contents: read
 
 on:
     push:


### PR DESCRIPTION
Potential fix for [https://github.com/brewbalance-team/BrewBalance/security/code-scanning/1](https://github.com/brewbalance-team/BrewBalance/security/code-scanning/1)

In general, to fix this class of issues, you add a `permissions:` section at the workflow root or at each job, specifying only the scopes required (e.g., `contents: read`). For a simple CI workflow that only needs to read the repository to run tests, `contents: read` is a sensible minimal configuration. This constrains the `GITHUB_TOKEN` so that even if defaults are broad (e.g., read-write), this workflow runs with reduced privileges.

For this specific file `.github/workflows/ci.yml`, the best, non-breaking change is to add a root-level `permissions:` block right after the `name:` declaration and before `on:`. That way, the setting applies to all jobs (current and future) in this workflow that do not override it. The content should be:

```yaml
permissions:
    contents: read
```

No imports or additional methods are needed because this is just a YAML configuration change. The only lines to modify are around the top of the file, inserting the new block after line 1 while leaving the rest of the workflow unchanged.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
